### PR TITLE
Update generate_rpm.sh for PostgreSQL 13

### DIFF
--- a/generate_rpm.sh
+++ b/generate_rpm.sh
@@ -3,7 +3,7 @@
 PROGNAME=$(basename ${0})
 RPMBUILD="./rpmbuild"
 RPMTEST="./rpmtest"
-PG_VERSIONS="9.4 9.5 9.6 10 11 12"
+PG_VERSIONS="9.4 9.5 9.6 10 11 12 13"
 CURRENT=`pwd`
 LOGDIR="log/`date +"%Y%m%d_%H%M%S"`"
 


### PR DESCRIPTION
Updated generate_rpm.sh for clarifying that PostgreSQL 13 can be specified in PG_VERSIONS.